### PR TITLE
Add guard for bot startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -236,9 +236,9 @@ def send_patch_notes():
 
 
 
-if patchnotes_sent == 0:
-    send_patch_notes()
-    patchnotes_sent = 1
+if __name__ == '__main__':
+    if patchnotes_sent == 0:
+        send_patch_notes()
+        patchnotes_sent = 1
 
-
-bot.polling()
+    bot.polling()


### PR DESCRIPTION
## Summary
- prevent bot from starting on import
- wrap patch note sending and `bot.polling()` under the usual `if __name__ == '__main__'` block

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6878fb83b1a08323ad15a440c508e6b9