### PR TITLE
Remove duplicate command list

### DIFF
--- a/commandconversion.py
+++ b/commandconversion.py
@@ -1,7 +1,4 @@
-from telebot import TeleBot
 from telebot.types import BotCommand
-import os
-from dotenv import load_dotenv
 
 def getCommands():
     commands = [

--- a/commands.py
+++ b/commands.py
@@ -1,40 +1,10 @@
 from telebot import TeleBot
 from telebot.types import BotCommand
-import os
-from dotenv import load_dotenv
-
-# Load environment variables
-load_dotenv()
-
-TOKEN = os.getenv('TELEGRAM_BOT_TOKEN')
-bot = TeleBot(TOKEN)
+from commandconversion import getCommands
 
 def register_commands(bot: TeleBot):
-    commands = [
-        BotCommand("hello", "Hello"),
-        BotCommand("random", "Funny random gen"),
-        BotCommand("cockfight","Cockfight"),
-        BotCommand("collectedPlayers","Show all collected players"),
-        BotCommand("playerScores", "Player scores"),
-        BotCommand("specialCockBonus","Special cock bonus"),
-        BotCommand("showCommands", "Shows all available commands"),
-        BotCommand("debug"," Debug messages to myself"),
-        BotCommand("testGroup", "Test group message"),
-        BotCommand("gaming", "Gaming time"),
-        BotCommand("all", "Tags all users"),
-        BotCommand("schuiz", "Schuiz command"),
-        BotCommand("gasperl","Gasperl command"),
-        BotCommand("kefa", "Kefa command"),
-        BotCommand("dahad", "Dahad command"),
-    ]
-
-
+    commands_dict = getCommands()
+    commands = [BotCommand(cmd, desc) for cmd, desc in commands_dict.items()]
     bot.set_my_commands(commands)
-
-
-
-register_commands(bot)
-
-
 
 

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from dotenv import load_dotenv
 import userManagement
 from cockmachine import *
 from commandconversion import getCommands
+from commands import register_commands
 from patchnotes import patchnotes
 from mediaManagement import *
 from userManagement import *
@@ -22,6 +23,7 @@ TOKEN = os.getenv('TELEGRAM_BOT_TOKEN')
 admin_chat = os.getenv('MY_CHAT_ID')
 group_chat = os.getenv('GROUP_CHAT_ID')
 bot = telebot.TeleBot(TOKEN)
+register_commands(bot)
 
 tracked_message_id = None
 tracked_user_name = None


### PR DESCRIPTION
## Summary
- only keep single source of bot commands
- set command list via `register_commands` inside `main.py`

## Testing
- `poetry run python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6878fb8a31e883239192c42122c4bca4